### PR TITLE
Replace link of use-the-distubrance preprint for doi

### DIFF
--- a/thesis/references.bib
+++ b/thesis/references.bib
@@ -1059,7 +1059,7 @@
   title		= {Should geophysicists use the gravity disturbance or the
 		  anomaly?},
   year		= {2018},
-  url		= {https://www.leouieda.com/papers/use-the-disturbance.html}
+  doi		= {10.5281/zenodo.1255306}
 }
 
 @Misc{		  oliveira2021,


### PR DESCRIPTION
The link to the use-the-disturbance preprint is broken, replaced the url for
its doi in the BibTeX entry.