### PR TITLE
Remueve línea errónea en uno de los ejemplos de Fatiando

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Usando BibTeX:
 ## Versiones
 
 - [PDF de la versión en desarrollo en rama `main`](https://github.com/santisoler/phd-thesis/raw/pdf/thesis.pdf)
+- [`v1.1.1`](https://github.com/santisoler/phd-thesis/releases/tag/v1.1.1): Versión corregida luego de la revisión por parte del Jurado, con una correción menor.
+- [`v1.0.0`](https://github.com/santisoler/phd-thesis/releases/tag/v1.0.0): Versión enviada para su evaluación ([descargar el PDF](https://github.com/santisoler/phd-thesis/releases/download/v1.0.0/thesis.pdf))
 - [`v1.1.0`](https://github.com/santisoler/phd-thesis/releases/tag/v1.1.0): Versión corregida luego de la revisión por parte del Jurado
 - [`v1.0.0`](https://github.com/santisoler/phd-thesis/releases/tag/v1.0.0): Versión enviada para su evaluación ([descargar el PDF](https://github.com/santisoler/phd-thesis/releases/download/v1.0.0/thesis.pdf))
 - [`v0.1.0`](https://github.com/santisoler/phd-thesis/releases/tag/v0.1.0): Primer borrador ([descargar el PDF](https://github.com/santisoler/phd-thesis/releases/download/v0.1.0/thesis.pdf))

--- a/thesis/fatiando-examples/harmonica-point.py
+++ b/thesis/fatiando-examples/harmonica-point.py
@@ -17,6 +17,5 @@ coordinates = vd.grid_coordinates(
 
 # Calculamos la componente vertical (hacia abajo) de la aceleracion gravitatoria
 gravity = hm.point_gravity(
->>>>>>> main:thesis/fatiando-examples/harmonica-point-mass.py
     coordinates, points, masses, field="g_z", coordinate_system="cartesian"
 )

--- a/thesis/variables.tex
+++ b/thesis/variables.tex
@@ -23,9 +23,9 @@
 }
 
 % Define version and publication date (should be hard coded before submission)
-\newcommand{\ThesisVersion}{1.1.0}
+\newcommand{\ThesisVersion}{1.1.1}
 % \DTMsavedate{publication}{\the\year-\the\month-\the\day}
-\DTMsavedate{publication}{2022-02-02}
+\DTMsavedate{publication}{2022-02-08}
 
 % DOIs
 \newcommand{\ThesisDOI}{10.6084/m9.figshare.16906909}


### PR DESCRIPTION
- Remueve una línea errónea en el ejemplo de Fatiando para masas puntuales.
- Cambia la versión de la Tesis a v1.1.1 y actualiza la fecha de última modificación.
